### PR TITLE
object-get-utils を CommonJS に変換

### DIFF
--- a/src/other/object-get-utils.js
+++ b/src/other/object-get-utils.js
@@ -7,7 +7,7 @@
  * @param {*} [defaultValue] The value returned for `undefined` resolved values.
  * @returns {*} Returns the resolved value.
  */
-export const get = (object, path, defaultValue) => {
+const get = (object, path, defaultValue) => {
   const pathArray = Array.isArray(path)
     ? path
     : path.replace(/[\[\]']+/g, '.').split('.').filter(Boolean);
@@ -20,4 +20,8 @@ export const get = (object, path, defaultValue) => {
     }
   }
   return result;
+};
+
+module.exports = {
+  get
 };

--- a/src/other/object-get-utils.test.js
+++ b/src/other/object-get-utils.test.js
@@ -1,4 +1,4 @@
-import { get } from './object-get-utils';
+const { get } = require('./object-get-utils');
 
 describe('get', () => {
   const object = { 'a': [{ 'b': { 'c': 3 } }, { d: 4 }] };


### PR DESCRIPTION
### 説明
object-get-utilsモジュールとそのテストファイルを、ES Modules (ESM) 形式から CommonJS
  形式にリファクタリングします。

  主な変更点
   - `object-get-utils.js`
     - export を module.exports に変更しました。
   - `object-get-utils.test.js`
     - import を require に変更しました。

<!--
このPRの説明
画像や動画(GIF)、APIの利用方法など書いてあると良い
-->

### 関連

<!--
関連するIssueやBacklogなどへのリンク
-->

### 共有事項(Shared Matters)

<!--
何か共有したいこと、残タスク等あれば
-->

### レビュワーの方へ（For Reviewers）
<!--
レビュー優先度が「至急/なる早」の場合はPRにレビュー優先度のラベルも設定すること
-->
- レビュー優先度(Priority): 通常
- 目安期間(Limit): 本日
- リリース日(Release Date): 未定
- QA開始予定日(QA Start Date): 未定