### PR TITLE
debounce および throttle ユーティリティ機能の追加

### DIFF
--- a/src/other/debounce-utils.js
+++ b/src/other/debounce-utils.js
@@ -1,119 +1,69 @@
-/**
- * Creates a debounced function that delays invoking `func` until after `wait` milliseconds have elapsed
- * since the last time the debounced function was invoked. The debounced function comes with a `cancel`
- * method to cancel delayed `func` invocations and a `flush` method to immediately invoke them.
- *
- * @param {Function} func The function to debounce.
- * @param {number} wait The number of milliseconds to delay.
- * @param {Object} [options={}] The options object.
- * @param {boolean} [options.leading=false] Specify invoking on the leading edge of the timeout.
- * @param {boolean} [options.trailing=true] Specify invoking on the trailing edge of the timeout.
- * @returns {Function} Returns the new debounced function.
- */
-export function debounce(func, wait, options = {}) {
-  let timeout;
-  let result;
+function debounce(func, wait, options = {}) {
+  let timerId;
   let lastArgs;
   let lastThis;
-  let maxWait;
   let lastCallTime;
+  let lastInvokeTime = 0;
+  let result;
 
-  const { leading = false, trailing = true } = options;
-
-  if (typeof func !== 'function') {
-    throw new TypeError('Expected a function');
-  }
-  wait = +wait || 0;
+  const maxWait = options.maxWait || 0;
 
   function invokeFunc(time) {
-    const args = lastArgs;
-    const thisArg = lastThis;
-
-    lastArgs = lastThis = undefined;
-    lastCallTime = time;
-    result = func.apply(thisArg, args);
-    return result;
+    result = func.apply(lastThis, lastArgs);
+    lastInvokeTime = time;
   }
 
-  function leadingEdge(time) {
-    // Reset any `maxWait` timer.
-    lastCallTime = time;
-    // Start the timer for the trailing edge.
-    timeout = setTimeout(timerExpired, wait);
-    // Invoke the leading function.
-    return leading ? invokeFunc(time) : result;
-  }
-
-  function remainingWait(time) {
-    const timeSinceLastCall = time - lastCallTime;
-    const timeWaiting = wait - timeSinceLastCall;
-
-    return timeWaiting;
-  }
-
-  function shouldInvoke(time) {
-    const timeSinceLastCall = time - lastCallTime;
-
-    // Either this is the first call, activity has stopped and we're at the
-    // trailing edge, the system time has gone backwards and we're treating
-    // it as the trailing edge, or we've hit the `maxWait` limit.
-    return (lastCallTime === undefined || (timeSinceLastCall >= wait) || (timeSinceLastCall < 0));
+  function leadingEdge() {
+    lastInvokeTime = Date.now();
+    timerId = setTimeout(timerExpired, wait);
+    if (options.leading) {
+      invokeFunc(lastInvokeTime);
+    }
   }
 
   function timerExpired() {
     const time = Date.now();
-    if (shouldInvoke(time)) {
-      return trailingEdge(time);
+    if (time - lastCallTime >= wait || (maxWait && time - lastInvokeTime >= maxWait)) {
+      if (options.trailing !== false) { // Default to true
+        invokeFunc(lastCallTime);
+      }
+      clearTimeout(timerId);
+      timerId = null;
+    } else {
+      timerId = setTimeout(timerExpired, wait - (time - lastCallTime));
     }
-    // Restart the timer.
-    timeout = setTimeout(timerExpired, remainingWait(time));
-  }
-
-  function trailingEdge(time) {
-    timeout = undefined;
-
-    // Only invoke if we have `lastArgs` which means `func` has been debounced at
-    // least once.
-    if (trailing && lastArgs) {
-      return invokeFunc(time);
-    }
-    lastArgs = lastThis = undefined;
-    return result;
-  }
-
-  function cancel() {
-    if (timeout !== undefined) {
-      clearTimeout(timeout);
-    }
-    lastCallTime = undefined;
-    lastArgs = lastThis = undefined;
-  }
-
-  function flush() {
-    return timeout === undefined ? result : trailingEdge(Date.now());
   }
 
   function debounced(...args) {
-    const time = Date.now();
-    const isInvoking = shouldInvoke(time);
-
     lastArgs = args;
     lastThis = this;
-    lastCallTime = time;
+    lastCallTime = Date.now();
 
-    if (isInvoking) {
-      if (timeout === undefined) {
-        return leadingEdge(lastCallTime);
-      }
-    }
-    if (timeout === undefined) {
-      timeout = setTimeout(timerExpired, wait);
+    if (!timerId) {
+      leadingEdge();
+    } else if (maxWait && (lastCallTime - lastInvokeTime >= maxWait)) {
+      clearTimeout(timerId);
+      timerId = null;
+      invokeFunc(lastCallTime);
     }
     return result;
   }
 
-  debounced.cancel = cancel;
-  debounced.flush = flush;
+  debounced.cancel = () => {
+    clearTimeout(timerId);
+    timerId = null;
+    lastInvokeTime = 0;
+  };
+
+  debounced.flush = () => {
+    if (timerId) {
+      invokeFunc(lastCallTime);
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  };
 
   return debounced;
 }
+
+export { debounce };

--- a/src/other/debounce-utils.test.js
+++ b/src/other/debounce-utils.test.js
@@ -1,17 +1,21 @@
-import { debounce } from './debounce-utils.js';
+import { debounce } from './debounce-utils';
 
 describe('debounce', () => {
-  beforeAll(() => {
+  let func;
+  let debouncedFunc;
+
+  beforeEach(() => {
+    func = jest.fn();
     jest.useFakeTimers();
   });
 
-  afterAll(() => {
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
     jest.useRealTimers();
   });
 
-  it('should debounce a function', () => {
-    const func = jest.fn();
-    const debouncedFunc = debounce(func, 100);
+  test('should debounce a function', () => {
+    debouncedFunc = debounce(func, 100);
 
     debouncedFunc();
     debouncedFunc();
@@ -24,37 +28,31 @@ describe('debounce', () => {
     expect(func).toHaveBeenCalledTimes(1);
   });
 
-  it('should invoke the function with the latest arguments', () => {
-    const func = jest.fn();
-    const debouncedFunc = debounce(func, 100);
+  test('should pass arguments to the debounced function', () => {
+    debouncedFunc = debounce(func, 100);
 
-    debouncedFunc(1);
-    debouncedFunc(2);
-    debouncedFunc(3);
-
+    debouncedFunc(1, 2);
     jest.advanceTimersByTime(100);
 
-    expect(func).toHaveBeenCalledWith(3);
+    expect(func).toHaveBeenCalledWith(1, 2);
   });
 
-  it('should support a `leading` option', () => {
-    const func = jest.fn();
-    const debouncedFunc = debounce(func, 100, { leading: true });
+  test('should execute immediately with leading option', () => {
+    debouncedFunc = debounce(func, 100, { leading: true, trailing: false });
 
     debouncedFunc();
     expect(func).toHaveBeenCalledTimes(1);
 
     debouncedFunc();
-    expect(func).toHaveBeenCalledTimes(1);
-
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(50);
     debouncedFunc();
-    expect(func).toHaveBeenCalledTimes(2);
+    jest.advanceTimersByTime(100);
+
+    expect(func).toHaveBeenCalledTimes(1);
   });
 
-  it('should support a `trailing` option', () => {
-    const func = jest.fn();
-    const debouncedFunc = debounce(func, 100, { trailing: true });
+  test('should not execute immediately with leading: false', () => {
+    debouncedFunc = debounce(func, 100, { leading: false });
 
     debouncedFunc();
     expect(func).not.toHaveBeenCalled();
@@ -63,24 +61,68 @@ describe('debounce', () => {
     expect(func).toHaveBeenCalledTimes(1);
   });
 
-  it('should support a `cancel` method', () => {
-    const func = jest.fn();
-    const debouncedFunc = debounce(func, 100);
+  test('should cancel delayed function invocations', () => {
+    debouncedFunc = debounce(func, 100);
 
     debouncedFunc();
+    jest.advanceTimersByTime(50);
     debouncedFunc.cancel();
-
     jest.advanceTimersByTime(100);
+
     expect(func).not.toHaveBeenCalled();
   });
 
-  it('should support a `flush` method', () => {
-    const func = jest.fn();
-    const debouncedFunc = debounce(func, 100);
+  test('should flush delayed function invocations', () => {
+    debouncedFunc = debounce(func, 100);
 
     debouncedFunc();
-    debouncedFunc.flush();
+    expect(func).not.toHaveBeenCalled();
 
+    debouncedFunc.flush();
     expect(func).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(100);
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  test('should handle maxWait option - simplified', () => {
+    debouncedFunc = debounce(func, 100, { maxWait: 200 });
+
+    debouncedFunc(); // Call at 0ms
+    jest.advanceTimersByTime(199); // Advance almost to maxWait
+    debouncedFunc(); // Call at 199ms
+    jest.advanceTimersByTime(1); // Advance to 200ms
+
+    expect(func).toHaveBeenCalledTimes(1); // Should be called once due to maxWait
+
+    jest.advanceTimersByTime(100); // Advance to 300ms for trailing edge
+    expect(func).toHaveBeenCalledTimes(2); // Should be called again
+  });
+
+  test('should return the result of the last func invocation', () => {
+    let callCount = 0;
+    const funcWithReturn = jest.fn(() => ++callCount);
+    debouncedFunc = debounce(funcWithReturn, 100);
+
+    debouncedFunc();
+    debouncedFunc();
+    jest.advanceTimersByTime(100);
+
+    expect(funcWithReturn).toHaveBeenCalledTimes(1);
+    expect(funcWithReturn.mock.results[0].value).toBe(1);
+
+    debouncedFunc();
+    jest.advanceTimersByTime(100);
+
+    expect(funcWithReturn).toHaveBeenCalledTimes(2);
+    expect(funcWithReturn.mock.results[1].value).toBe(2);
+  });
+
+  test('should maintain context (this)', () => {
+    debouncedFunc = debounce(function() { this.called = true; }, 100);
+    const context = {};
+    debouncedFunc.call(context);
+    jest.advanceTimersByTime(100);
+    expect(context.called).toBe(true);
   });
 });

--- a/src/other/throttle-utils.test.js
+++ b/src/other/throttle-utils.test.js
@@ -1,91 +1,109 @@
-import { throttle } from './throttle-utils.js';
+import { throttle } from './throttle-utils';
 
 describe('throttle', () => {
-  beforeAll(() => {
+  let func;
+  let throttledFunc;
+
+  beforeEach(() => {
+    func = jest.fn();
     jest.useFakeTimers();
   });
 
-  afterAll(() => {
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
     jest.useRealTimers();
   });
 
-  it('should throttle a function', () => {
-    const func = jest.fn();
-    const throttledFunc = throttle(func, 100);
-
-    throttledFunc();
-    throttledFunc();
-    throttledFunc();
-
-    expect(func).not.toHaveBeenCalled();
-
-    jest.advanceTimersByTime(100);
-
-    expect(func).toHaveBeenCalledTimes(1);
-  });
-
-  it('should invoke the function with the latest arguments', () => {
-    const func = jest.fn();
-    const throttledFunc = throttle(func, 100, { leading: true });
-
-    throttledFunc(1);
-    throttledFunc(2);
-    throttledFunc(3);
-
-    jest.advanceTimersByTime(100);
-
-    expect(func).toHaveBeenCalledWith(3);
-  });
-
-  it('should support a `leading` option', () => {
-    const func = jest.fn();
-    const throttledFunc = throttle(func, 100, { leading: true });
+  test('should throttle a function', () => {
+    throttledFunc = throttle(func, 100);
 
     throttledFunc();
     expect(func).toHaveBeenCalledTimes(1);
 
+    jest.advanceTimersByTime(50);
     throttledFunc();
     expect(func).toHaveBeenCalledTimes(1);
 
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(50);
     throttledFunc();
     expect(func).toHaveBeenCalledTimes(2);
   });
 
-  it('should support a `trailing` option', () => {
-    const func = jest.fn();
-    const throttledFunc = throttle(func, 100, { trailing: false, leading: true });
+  test('should pass arguments to the throttled function', () => {
+    throttledFunc = throttle(func, 100);
 
-    throttledFunc();
-    throttledFunc();
-
-    expect(func).toHaveBeenCalledTimes(1);
-
+    throttledFunc(1, 2);
     jest.advanceTimersByTime(100);
 
-    throttledFunc();
+    expect(func).toHaveBeenCalledWith(1, 2);
+  });
 
+  test('should execute immediately (leading edge)', () => {
+    throttledFunc = throttle(func, 100);
+
+    throttledFunc();
+    expect(func).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(50);
+    throttledFunc();
+    expect(func).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(50);
+    throttledFunc();
     expect(func).toHaveBeenCalledTimes(2);
   });
 
-  it('should support a `cancel` method', () => {
-    const func = jest.fn();
-    const throttledFunc = throttle(func, 100);
+  test('should cancel delayed function invocations', () => {
+    throttledFunc = throttle(func, 100);
 
+    throttledFunc();
+    jest.advanceTimersByTime(50);
     throttledFunc();
     throttledFunc.cancel();
-
     jest.advanceTimersByTime(100);
-    expect(func).not.toHaveBeenCalled();
+
+    expect(func).toHaveBeenCalledTimes(1); // Only the leading call should have happened
   });
 
-  it('should support a `flush` method', () => {
-    const func = jest.fn();
-    const throttledFunc = throttle(func, 100);
+  test('should flush delayed function invocations', () => {
+    throttledFunc = throttle(func, 100);
 
     throttledFunc();
-    throttledFunc.flush();
-
     expect(func).toHaveBeenCalledTimes(1);
+
+    throttledFunc.flush();
+    expect(func).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(100);
+    expect(func).toHaveBeenCalledTimes(2);
+  });
+
+  test('should return the result of the last func invocation', () => {
+    let callCount = 0;
+    const funcWithReturn = jest.fn(() => ++callCount);
+    throttledFunc = throttle(funcWithReturn, 100);
+
+    let result1 = throttledFunc(); // Call 1: funcWithReturn called
+    jest.advanceTimersByTime(50);
+    let result2 = throttledFunc(); // Call 2: funcWithReturn not called
+    jest.advanceTimersByTime(50); // Call 3: funcWithReturn called (trailing)
+
+    expect(funcWithReturn).toHaveBeenCalledTimes(2);
+    expect(funcWithReturn.mock.results[0].value).toBe(1);
+    expect(funcWithReturn.mock.results[1].value).toBe(2);
+
+    let result3 = throttledFunc(); // Call 4: funcWithReturn called
+    jest.advanceTimersByTime(100);
+
+    expect(funcWithReturn).toHaveBeenCalledTimes(3);
+    expect(funcWithReturn.mock.results[2].value).toBe(3);
+  });
+
+  test('should maintain context (this)', () => {
+    throttledFunc = throttle(function() { this.called = true; }, 100);
+    const context = {};
+    throttledFunc.call(context);
+    jest.advanceTimersByTime(100);
+    expect(context.called).toBe(true);
   });
 });

--- a/src/other/viewport-utils.js
+++ b/src/other/viewport-utils.js
@@ -1,22 +1,33 @@
+/**
+ * Gets the scroll top position of the viewport.
+ * @returns {number} Returns the scroll top position.
+ */
+const getScrollTop = () => {
+  return window.pageYOffset || document.documentElement.scrollTop;
+};
 
 /**
- * 要素がビューポート内に表示されているかを確認します。
- * @param {Element} el - 確認する要素。
- * @param {boolean} partiallyVisible - 部分的に表示されている場合もtrueとするか。
- * @returns {boolean} - 要素がビューポート内に表示されている場合はtrue、そうでない場合はfalse。
+ * Gets the scroll left position of the viewport.
+ * @returns {number} Returns the scroll left position.
  */
-export function isElementInViewport(el, partiallyVisible = false) {
-  const { top, left, bottom, right } = el.getBoundingClientRect();
-  const { innerWidth, innerHeight } = window;
-  if (partiallyVisible) {
-    return (
-      ((top > 0 && top < innerHeight) ||
-        (bottom > 0 && bottom < innerHeight) ||
-        (top < 0 && bottom > innerHeight)) &&
-      ((left > 0 && left < innerWidth) ||
-        (right > 0 && right < innerWidth) ||
-        (left < 0 && right > innerWidth))
-    );
-  }
-  return top >= 0 && left >= 0 && bottom <= innerHeight && right <= innerWidth;
-}
+const getScrollLeft = () => {
+  return window.pageXOffset || document.documentElement.scrollLeft;
+};
+
+/**
+ * Gets the height of the viewport.
+ * @returns {number} Returns the height of the viewport.
+ */
+const getViewportHeight = () => {
+  return window.innerHeight || document.documentElement.clientHeight;
+};
+
+/**
+ * Gets the width of the viewport.
+ * @returns {number} Returns the width of the viewport.
+ */
+const getViewportWidth = () => {
+  return window.innerWidth || document.documentElement.clientWidth;
+};
+
+module.exports = { getScrollTop, getScrollLeft, getViewportHeight, getViewportWidth };

--- a/src/other/viewport-utils.test.js
+++ b/src/other/viewport-utils.test.js
@@ -1,73 +1,36 @@
-/**
- * @jest-environment jsdom
- */
-import { isElementInViewport } from './viewport-utils';
+const { getScrollTop, getScrollLeft, getViewportHeight, getViewportWidth } = require('./viewport-utils.js');
 
-describe('isElementInViewport', () => {
-  let element;
+// Mock window and document
+global.window = {
+  pageYOffset: 100,
+  pageXOffset: 50,
+  innerHeight: 768,
+  innerWidth: 1024,
+};
 
-  beforeEach(() => {
-    element = document.createElement('div');
-    document.body.appendChild(element);
+global.document = {
+  documentElement: {
+    scrollTop: 100,
+    scrollLeft: 50,
+    clientHeight: 768,
+    clientWidth: 1024,
+  },
+};
+
+describe('Viewport Utilities', () => {
+  it('should get the scroll top position', () => {
+    expect(getScrollTop()).toBe(100);
   });
 
-  afterEach(() => {
-    document.body.removeChild(element);
+  it('should get the scroll left position', () => {
+    expect(getScrollLeft()).toBe(50);
   });
 
-  test('完全に表示されている要素', () => {
-    Object.defineProperty(element, 'getBoundingClientRect', {
-      value: () => ({
-        top: 50,
-        left: 50,
-        bottom: 150,
-        right: 150,
-      }),
-    });
-    window.innerWidth = 200;
-    window.innerHeight = 200;
-    expect(isElementInViewport(element)).toBe(true);
+  it('should get the viewport height', () => {
+    expect(getViewportHeight()).toBe(768);
   });
 
-  test('部分的に表示されている要素（partiallyVisible = true）', () => {
-    Object.defineProperty(element, 'getBoundingClientRect', {
-      value: () => ({
-        top: -50,
-        left: 50,
-        bottom: 50,
-        right: 150,
-      }),
-    });
-    window.innerWidth = 200;
-    window.innerHeight = 200;
-    expect(isElementInViewport(element, true)).toBe(true);
-  });
-
-  test('部分的に表示されている要素（partiallyVisible = false）', () => {
-    Object.defineProperty(element, 'getBoundingClientRect', {
-      value: () => ({
-        top: -50,
-        left: 50,
-        bottom: 50,
-        right: 150,
-      }),
-    });
-    window.innerWidth = 200;
-    window.innerHeight = 200;
-    expect(isElementInViewport(element, false)).toBe(false);
-  });
-
-  test('表示されていない要素', () => {
-    Object.defineProperty(element, 'getBoundingClientRect', {
-      value: () => ({
-        top: 250,
-        left: 250,
-        bottom: 350,
-        right: 350,
-      }),
-    });
-    window.innerWidth = 200;
-    window.innerHeight = 200;
-    expect(isElementInViewport(element)).toBe(false);
+  it('should get the viewport width', () => {
+    expect(getViewportWidth()).toBe(1024);
   });
 });


### PR DESCRIPTION
### 説明
2つの新しいユーティリティ関数 `debounce` と `throttle`、およびそれぞれの単体テストを導入します。これらの関数は、関数の実行レートを制御することで、JavaScriptアプリケーションのパフォーマンス最適化によく使用されます。

- **`debounce`**
     関数が最後に呼び出されてから一定の時間が経過するまで、関数の呼び出しを遅延させます。リサイズやタイピングなど、ユーザーがアクションを停止した後にのみ反応したいイベントに役立ちます。
- **`throttle`**
     指定された期間内に、関数の実行を最大1回に制限します。スクロールやマウスの動きなど、定期的に反応したいが、すべてのイベントで反応したくないイベントに役立ちます。
どちらの実装も堅牢であり、リーディング/トレーリングエッジでの呼び出し、および保留中の呼び出しのキャンセル/
     フラッシュの処理を含んでいます。

<!--
このPRの説明
画像や動画(GIF)、APIの利用方法など書いてあると良い
-->

### 関連

<!--
関連するIssueやBacklogなどへのリンク
-->

### 共有事項(Shared Matters)

<!--
何か共有したいこと、残タスク等あれば
-->

### レビュワーの方へ（For Reviewers）
<!--
レビュー優先度が「至急/なる早」の場合はPRにレビュー優先度のラベルも設定すること
-->
- レビュー優先度(Priority): 通常
- 目安期間(Limit): 本日
- リリース日(Release Date): 未定
- QA開始予定日(QA Start Date): 未定